### PR TITLE
Potential fixes for Code Scanning Alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/src/utils/codeAnalysis.ts
+++ b/src/utils/codeAnalysis.ts
@@ -93,7 +93,7 @@ function calculateFilePriority(filePath: string, size: number): number {
 function shouldIgnoreFile(filePath: string, ignorePatterns: string[]): boolean {
   const relativePath = path.relative(process.cwd(), filePath);
   return ignorePatterns.some(pattern => {
-    const regex = new RegExp(pattern.replace(/\*/g, '.*').replace(/\//g, '\\/'));
+    const regex = new RegExp(pattern.replace(/\\/g, '\\\\').replace(/\*/g, '.*').replace(/\//g, '\\/'));
     return regex.test(relativePath);
   });
 }
@@ -107,7 +107,7 @@ function shouldIgnoreFile(filePath: string, ignorePatterns: string[]): boolean {
 function shouldIncludeFile(filePath: string, includePatterns: string[]): boolean {
   const relativePath = path.relative(process.cwd(), filePath);
   return includePatterns.some(pattern => {
-    const regex = new RegExp(pattern.replace(/\*/g, '.*').replace(/\//g, '\\/'));
+    const regex = new RegExp(pattern.replace(/\\/g, '\\\\').replace(/\*/g, '.*').replace(/\//g, '\\/'));
     return regex.test(relativePath);
   });
 }

--- a/src/utils/codeAnalysis.ts
+++ b/src/utils/codeAnalysis.ts
@@ -93,7 +93,9 @@ function calculateFilePriority(filePath: string, size: number): number {
 function shouldIgnoreFile(filePath: string, ignorePatterns: string[]): boolean {
   const relativePath = path.relative(process.cwd(), filePath);
   return ignorePatterns.some(pattern => {
-    const regex = new RegExp(pattern.replace(/\\/g, '\\\\').replace(/\*/g, '.*').replace(/\//g, '\\/'));
+    const regex = new RegExp(
+      pattern.replace(/\\/g, '\\\\').replace(/\*/g, '.*').replace(/\//g, '\\/')
+    );
     return regex.test(relativePath);
   });
 }
@@ -107,7 +109,9 @@ function shouldIgnoreFile(filePath: string, ignorePatterns: string[]): boolean {
 function shouldIncludeFile(filePath: string, includePatterns: string[]): boolean {
   const relativePath = path.relative(process.cwd(), filePath);
   return includePatterns.some(pattern => {
-    const regex = new RegExp(pattern.replace(/\\/g, '\\\\').replace(/\*/g, '.*').replace(/\//g, '\\/'));
+    const regex = new RegExp(
+      pattern.replace(/\\/g, '\\\\').replace(/\*/g, '.*').replace(/\//g, '\\/')
+    );
     return regex.test(relativePath);
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/moiz-imran/perf-lens/security/code-scanning/3](https://github.com/moiz-imran/perf-lens/security/code-scanning/3)

To fix the problem, we need to ensure that backslashes in the input patterns are properly escaped before converting glob patterns to regular expressions. This can be achieved by adding an additional `replace` call to escape backslashes. The best way to fix this without changing existing functionality is to modify the `shouldIgnoreFile` and `shouldIncludeFile` functions to include this additional escaping step.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
